### PR TITLE
Added a way to customize the name of the database objects that are added for easy identification. 

### DIFF
--- a/TableDependency.SqlClient/Enumerations/SqlServerRequiredPermission.cs
+++ b/TableDependency.SqlClient/Enumerations/SqlServerRequiredPermission.cs
@@ -27,6 +27,7 @@ using System.ComponentModel;
 
 namespace TableDependency.SqlClient.Enumerations
 {
+    //testing
     /// <summary>
     /// https://msdn.microsoft.com/en-us/library/ms178569.aspx
     /// </summary>

--- a/TableDependency.SqlClient/SqlTableDependency.cs
+++ b/TableDependency.SqlClient/SqlTableDependency.cs
@@ -126,6 +126,7 @@ namespace TableDependency.SqlClient
         /// <param name="filter">The filter condition translated in WHERE.</param>
         /// <param name="notifyOn">The notify on Insert, Delete, Update operation.</param>
         /// <param name="executeUserPermissionCheck">if set to <c>true</c> [execute user permission check].</param>
+        /// <param name="dataBaseObjectNamePrefix">A string value to prefix all database objects with. Allows the objects to quickly be identified.</param>
         public SqlTableDependency(
             string connectionString,
             string tableName = null,
@@ -133,7 +134,8 @@ namespace TableDependency.SqlClient
             IUpdateOfModel<T> updateOf = null,
             ITableDependencyFilter filter = null,
             DmlTriggerType notifyOn = DmlTriggerType.All,
-            bool executeUserPermissionCheck = false) : base(connectionString, tableName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck)
+            bool executeUserPermissionCheck = false,
+            string dataBaseObjectNamePrefix = null) : base(connectionString, tableName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck,dataBaseObjectNamePrefix)
         {
         }
 
@@ -352,11 +354,16 @@ namespace TableDependency.SqlClient
             return processableMessages;
         }
 
-        protected override string GetBaseObjectsNamingConvention()
+        
+        protected override string GetBaseObjectsNamingConvention(string dataBaseObjectNamePrefix)
         {
             var name = $"{_schemaName}_{_tableName}";
-            return $"{name}_{Guid.NewGuid()}";
+            if (!string.IsNullOrEmpty(dataBaseObjectNamePrefix))
+                name = $"{dataBaseObjectNamePrefix}__{name}";
+             return $"{name}_{Guid.NewGuid()}";
         }
+
+        
 
         protected override void DropDatabaseObjects(string connectionString, string databaseObjectsNaming)
         {

--- a/TableDependency.SqlClient/SqlTableDependency.cs
+++ b/TableDependency.SqlClient/SqlTableDependency.cs
@@ -62,6 +62,7 @@ namespace TableDependency.SqlClient
         protected Guid DialogHandle;
         protected const string DisposeMessageTemplate = "{0}/Dispose";
         protected const string StartMessageTemplate = "{0}/StartDialog/{1}";
+        protected string defalutDataBaseObjectNamePrefix = String.Empty;
 
         #endregion
 
@@ -126,18 +127,32 @@ namespace TableDependency.SqlClient
         /// <param name="filter">The filter condition translated in WHERE.</param>
         /// <param name="notifyOn">The notify on Insert, Delete, Update operation.</param>
         /// <param name="executeUserPermissionCheck">if set to <c>true</c> [execute user permission check].</param>
-        /// <param name="dataBaseObjectNamePrefix">A string value to prefix all database objects with. Allows the objects to quickly be identified.</param>
-        public SqlTableDependency(
+       public SqlTableDependency(
             string connectionString,
             string tableName = null,
             IModelToTableMapper<T> mapper = null,
             IUpdateOfModel<T> updateOf = null,
             ITableDependencyFilter filter = null,
             DmlTriggerType notifyOn = DmlTriggerType.All,
-            bool executeUserPermissionCheck = false,
-            string dataBaseObjectNamePrefix = null) : base(connectionString, tableName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck,dataBaseObjectNamePrefix)
+            bool executeUserPermissionCheck = false
+            ) : base(connectionString,  tableName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck)
         {
         }
+        public SqlTableDependency(
+            string connectionString,
+            string dataBaseObjectNamePrefix,
+            string tableName = null,
+            IModelToTableMapper<T> mapper = null,
+            IUpdateOfModel<T> updateOf = null,
+            ITableDependencyFilter filter = null,
+            DmlTriggerType notifyOn = DmlTriggerType.All,
+            bool executeUserPermissionCheck = false
+        ) : base(connectionString,  tableName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck)
+        {
+            defalutDataBaseObjectNamePrefix = dataBaseObjectNamePrefix;
+        }
+
+
 
         #endregion
 
@@ -355,12 +370,14 @@ namespace TableDependency.SqlClient
         }
 
         
-        protected override string GetBaseObjectsNamingConvention(string dataBaseObjectNamePrefix)
+        protected override string GetBaseObjectsNamingConvention()
         {
             var name = $"{_schemaName}_{_tableName}";
-            if (!string.IsNullOrEmpty(dataBaseObjectNamePrefix))
-                name = $"{dataBaseObjectNamePrefix}__{name}";
-             return $"{name}_{Guid.NewGuid()}";
+            if (!string.IsNullOrEmpty(defalutDataBaseObjectNamePrefix))
+            {
+                name = $"{defalutDataBaseObjectNamePrefix}__{name}";
+            }
+            return $"{name}_{Guid.NewGuid()}";
         }
 
         

--- a/TableDependency.SqlClient/TableDependency.SqlClient.csproj
+++ b/TableDependency.SqlClient/TableDependency.SqlClient.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>TableDependency.SqlClient.pfx</AssemblyOriginatorKeyFile>

--- a/TableDependency.Tests/TableDependency.IntegrationTest/RowVersionType.cs
+++ b/TableDependency.Tests/TableDependency.IntegrationTest/RowVersionType.cs
@@ -69,7 +69,8 @@ namespace TableDependency.IntegrationTest
 
             try
             {
-                tableDependency = new SqlTableDependency<RowVersioneModel>(ConnectionString, TableName);
+                tableDependency = new SqlTableDependency<RowVersioneModel>(ConnectionString,TableName);
+             //   tableDependency = new SqlTableDependency<RowVersioneModel>(ConnectionString, TableName);
                 tableDependency.OnChanged += this.TableDependency_Changed;
                 tableDependency.Start();
 

--- a/TableDependency/TableDependency.cs
+++ b/TableDependency/TableDependency.cs
@@ -167,7 +167,7 @@ namespace TableDependency
             IUpdateOfModel<T> updateOf = null,
             ITableDependencyFilter filter = null,
             DmlTriggerType dmlTriggerType = DmlTriggerType.All,
-            bool executeUserPermissionCheck = false)
+            bool executeUserPermissionCheck = false, string dataBaseObjectNamePrefix = null)
         {
             if (mapper?.Count() == 0) throw new UpdateOfException("mapper parameter is empty.");
             if (updateOf?.Count() == 0) throw new UpdateOfException("updateOf parameter is empty.");
@@ -198,7 +198,7 @@ namespace TableDependency
             if (!_userInterestedColumns.Any()) throw new NoMatchBetweenModelAndTableColumns();
             this.CheckIfUserInterestedColumnsCanBeManaged(_userInterestedColumns);
 
-            _dataBaseObjectsNamingConvention = this.GetBaseObjectsNamingConvention();
+            _dataBaseObjectsNamingConvention = this.GetBaseObjectsNamingConvention(dataBaseObjectNamePrefix);
             _dmlTriggerType = dmlTriggerType;
             _filter = filter;
         }
@@ -485,7 +485,7 @@ namespace TableDependency
 
         protected abstract IEnumerable<ColumnInfo> GetTableColumnsList(string connectionString);
 
-        protected abstract string GetBaseObjectsNamingConvention();
+        protected abstract string GetBaseObjectsNamingConvention(string dataBaseObjectNamePrefix);
 
         protected abstract string GetDataBaseName(string connectionString);
 

--- a/TableDependency/TableDependency.cs
+++ b/TableDependency/TableDependency.cs
@@ -64,6 +64,7 @@ namespace TableDependency
         protected bool _disposed;
         protected string _dataBaseObjectsNamingConvention;
 
+
         #endregion
 
         #region Events
@@ -167,7 +168,7 @@ namespace TableDependency
             IUpdateOfModel<T> updateOf = null,
             ITableDependencyFilter filter = null,
             DmlTriggerType dmlTriggerType = DmlTriggerType.All,
-            bool executeUserPermissionCheck = false, string dataBaseObjectNamePrefix = null)
+            bool executeUserPermissionCheck = false)
         {
             if (mapper?.Count() == 0) throw new UpdateOfException("mapper parameter is empty.");
             if (updateOf?.Count() == 0) throw new UpdateOfException("updateOf parameter is empty.");
@@ -198,7 +199,7 @@ namespace TableDependency
             if (!_userInterestedColumns.Any()) throw new NoMatchBetweenModelAndTableColumns();
             this.CheckIfUserInterestedColumnsCanBeManaged(_userInterestedColumns);
 
-            _dataBaseObjectsNamingConvention = this.GetBaseObjectsNamingConvention(dataBaseObjectNamePrefix);
+            _dataBaseObjectsNamingConvention = this.GetBaseObjectsNamingConvention();
             _dmlTriggerType = dmlTriggerType;
             _filter = filter;
         }
@@ -485,7 +486,7 @@ namespace TableDependency
 
         protected abstract IEnumerable<ColumnInfo> GetTableColumnsList(string connectionString);
 
-        protected abstract string GetBaseObjectsNamingConvention(string dataBaseObjectNamePrefix);
+        protected abstract string GetBaseObjectsNamingConvention();
 
         protected abstract string GetDataBaseName(string connectionString);
 

--- a/TableDependency/TableDependency.csproj
+++ b/TableDependency/TableDependency.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>TableDependency.pfx</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
There was a need by one of my customers to be able to identify which objects were added to their database by our application.  I added the ability to add a custom string to the beginning of each object that is added to the database.  By default the string is empty and the SQLTableDependency behaves the same as it has always behaved.  But if you add a string to the constructor it will pre-pend the string to the standard naming of objects added to the database.
Signing was turned off as I didn't have the password to enable it.  The same certificates are in the project the signing of the assemblies has just been turned off so I could build and run the test suite.

 