### PR TITLE
Add non-generic ITableDependency

### DIFF
--- a/TableDependency/Abstracts/ITableDependency.cs
+++ b/TableDependency/Abstracts/ITableDependency.cs
@@ -32,11 +32,10 @@ using TableDependency.Enums;
 
 namespace TableDependency.Abstracts
 {
-    public interface ITableDependency<T> where T : class, new()
+    public interface ITableDependency
     {
         #region Events
 
-        event ChangedEventHandler<T> OnChanged;
         event ErrorEventHandler OnError;
         event StatusEventHandler OnStatusChanged;
 
@@ -59,6 +58,15 @@ namespace TableDependency.Abstracts
         string DataBaseObjectsNamingConvention { get; }
         string TableName { get; }
         string SchemaName { get; }
+
+        #endregion
+    }
+
+    public interface ITableDependency<T> : ITableDependency where T : class, new()
+    {
+        #region Events
+
+        event ChangedEventHandler<T> OnChanged;
 
         #endregion
     }


### PR DESCRIPTION
This PR makes a minor change. It adds a non-generic interface `ITableDependency` and moves most of `ITableDependenc<T>`'s methods to it. Only `event ChangedEventHandler<T> OnChanged;` is left in `ITableDependency<T>`.

This allows me to have a `List<ITableDependency>` where each item in the list is a generic instance. Sample code:

```c#
var myList = new List<ITableDependency>()
{
    new SqlTableDependency<Person>(connectionString),
    new SqlTableDependency<Person2>(connectionString)
};

foreach (var d in myList)
    d.Start();
```

Currently this code above isn't possible.