### PR TITLE
Base non generic TableDependency on IDisposable

### DIFF
--- a/TableDependency/Abstracts/ITableDependency.cs
+++ b/TableDependency/Abstracts/ITableDependency.cs
@@ -32,11 +32,10 @@ using TableDependency.Enums;
 
 namespace TableDependency.Abstracts
 {
-    public interface ITableDependency<T> where T : class, new()
+    public interface ITableDependency
     {
         #region Events
 
-        event ChangedEventHandler<T> OnChanged;
         event ErrorEventHandler OnError;
         event StatusEventHandler OnStatusChanged;
 
@@ -59,6 +58,15 @@ namespace TableDependency.Abstracts
         string DataBaseObjectsNamingConvention { get; }
         string TableName { get; }
         string SchemaName { get; }
+
+        #endregion
+    }
+
+    public interface ITableDependency<T> : ITableDependency where T : class, new()
+    {
+        #region Events
+
+        event ChangedEventHandler<T> OnChanged;
 
         #endregion
     }

--- a/TableDependency/Abstracts/ITableDependency.cs
+++ b/TableDependency/Abstracts/ITableDependency.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -32,7 +33,7 @@ using TableDependency.Enums;
 
 namespace TableDependency.Abstracts
 {
-    public interface ITableDependency
+    public interface ITableDependency : IDisposable
     {
         #region Events
 

--- a/TableDependency/TableDependency.cs
+++ b/TableDependency/TableDependency.cs
@@ -44,7 +44,7 @@ using TableDependency.Utilities;
 
 namespace TableDependency
 {
-    public abstract class TableDependency<T> : ITableDependency<T>, IDisposable where T : class, new()
+    public abstract class TableDependency<T> : ITableDependency<T> where T : class, new()
     {
         #region Instance Variables
 


### PR DESCRIPTION
Depends on #76 (merge that first).

This PR moves the `IDisposable` basing to `ITableDepedency` so that I can call `.Dispose()` on a variable of type `ITableDependency`.