### PR TITLE
Let AddMapping return ModelToTableMapper<T>

### DIFF
--- a/TableDependency/ModelToTableMapper.cs
+++ b/TableDependency/ModelToTableMapper.cs
@@ -54,7 +54,7 @@ namespace TableDependency
         /// </summary>
         /// <param name="pi">The pi.</param>
         /// <param name="columnName">Name of the column.</param>
-        public void AddMapping(PropertyInfo pi, string columnName)
+        public ModelToTableMapper<T> AddMapping(PropertyInfo pi, string columnName)
         {
             if (_mappings.Values.Any(cn => cn == columnName))
             {
@@ -62,6 +62,8 @@ namespace TableDependency
             }
 
             _mappings[pi] = columnName;
+
+            return this;
         }
 
         /// <summary>

--- a/TableDependency/ModelToTableMapper.cs
+++ b/TableDependency/ModelToTableMapper.cs
@@ -76,20 +76,20 @@ namespace TableDependency
         {
             if (string.IsNullOrWhiteSpace(columnName)) throw new ModelToTableMapperException("ModelToTableMapper cannot contains null or empty strings.");
 
-            var memberExpression = expression.Body as MemberExpression;
-            if (memberExpression != null)
+            if (expression.Body is MemberExpression memberExpression)
             {
                 _mappings[(PropertyInfo)memberExpression.Member] = columnName;
                 return this;
             }
 
             var unarUnaryExpressionyExp = expression.Body as UnaryExpression;
-            var memberExpressionByOperator = unarUnaryExpressionyExp?.Operand as MemberExpression;
-            if (memberExpressionByOperator == null) throw new UpdateOfModelException("The 'expression' parameter should be a member expression.");
+            if (unarUnaryExpressionyExp?.Operand is MemberExpression memberExpressionByOperator)
+            {
+                _mappings[(PropertyInfo)memberExpressionByOperator.Member] = columnName;
+                return this;
+            }
 
-            _mappings[(PropertyInfo)memberExpressionByOperator.Member] = columnName;
-
-            return this;
+            throw new UpdateOfModelException("The 'expression' parameter should be a member expression.");
         }
 
         /// <summary>

--- a/TableDependency/TableDependency.cs
+++ b/TableDependency/TableDependency.cs
@@ -416,7 +416,7 @@ namespace TableDependency
             // If model property is mapped to table column keep it
             foreach (var tableColumn in tableColumnsList)
             {
-                if (string.Equals(tableColumn.Name.ToLowerInvariant(), propertyName.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(tableColumn.Name, propertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     return tableColumn.Name;
                 }

--- a/Tests/TableDependency.SqlClient.Where.UnitTests/UnitTestContains.cs
+++ b/Tests/TableDependency.SqlClient.Where.UnitTests/UnitTestContains.cs
@@ -94,7 +94,7 @@ namespace TableDependency.SqlClient.Where.UnitTests
             var where = new SqlTableDependencyFilter<Product>(expression).Translate();
 
             // Assert
-            Assert.AreEqual("[ExcangeRate] IN (123.45,432.1)", where);
+            Assert.AreEqual($"[ExcangeRate] IN ({123.45},{432.1})", where);
         }
 
         [TestMethod]


### PR DESCRIPTION
To provide a consistent API, I changed the return type of AddMapping from `void` to `ModelToTableMapper<T>`, which is also returned by the other overload.