### PR TITLE
Allow overriding WriteTraceMessage()

### DIFF
--- a/TableDependency/TableDependency.cs
+++ b/TableDependency/TableDependency.cs
@@ -314,7 +314,7 @@ namespace TableDependency
             }
         }
 
-        protected void WriteTraceMessage(TraceLevel traceLevel, string message, Exception exception = null)
+        virtual protected void WriteTraceMessage(TraceLevel traceLevel, string message, Exception exception = null)
         {
             try
             {


### PR DESCRIPTION
Allow overriding WriteTraceMessage() by adding virtual to method signature