### PR TITLE
Improve the ServiceBrokerNotEnabledException message

### DIFF
--- a/TableDependency.SqlClient/Exceptions/ServiceBrokerNotEnabledException.cs
+++ b/TableDependency.SqlClient/Exceptions/ServiceBrokerNotEnabledException.cs
@@ -35,7 +35,7 @@ namespace TableDependency.SqlClient.Exceptions
         { }
 
         protected internal ServiceBrokerNotEnabledException(string database)
-            : base($"Service broker is not enabled. Please activate it using 'ALTER DATABASE {database} SET ENABLE_BROKER' command.")
+            : base($"Service broker is not enabled. Please activate it using 'ALTER DATABASE {database} SET ENABLE_BROKER WITH ROLLBACK IMMEDIATE' command.")
         { }
     }
 }

--- a/TableDependency.SqlClient/Exceptions/ServiceBrokerNotEnabledException.cs
+++ b/TableDependency.SqlClient/Exceptions/ServiceBrokerNotEnabledException.cs
@@ -31,7 +31,11 @@ namespace TableDependency.SqlClient.Exceptions
     public class ServiceBrokerNotEnabledException : TableDependencyException
     {
         protected internal ServiceBrokerNotEnabledException()
-            : base("Service broker not enable. Please activete it using 'ALTER DATABASE MyDatabase SET ENABLE_BROKER' command.")
+            : this("MyDatabase")
+        { }
+
+        protected internal ServiceBrokerNotEnabledException(string database)
+            : base($"Service broker is not enabled. Please activate it using 'ALTER DATABASE {database} SET ENABLE_BROKER' command.")
         { }
     }
 }

--- a/TableDependency.SqlClient/SqlTableDependency.cs
+++ b/TableDependency.SqlClient/SqlTableDependency.cs
@@ -971,7 +971,23 @@ namespace TableDependency.SqlClient
                 using (var sqlCommand = sqlConnection.CreateCommand())
                 {
                     sqlCommand.CommandText = "SELECT is_broker_enabled FROM sys.databases WITH (NOLOCK) WHERE database_id = db_id();";
-                    if ((bool)sqlCommand.ExecuteScalar() == false) throw new ServiceBrokerNotEnabledException();
+                    if ((bool)sqlCommand.ExecuteScalar() == false)
+                    {
+                        string database;
+                        try
+                        {
+                            database = new SqlConnectionStringBuilder(_connectionString).InitialCatalog;
+                        }
+                        catch
+                        {
+                            database = null;
+                        }
+                        if (!string.IsNullOrEmpty(database))
+                        {
+                            throw new ServiceBrokerNotEnabledException(database);
+                        }
+                        throw new ServiceBrokerNotEnabledException();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Include the actual database name (Initial Catalog from the connection string) in the command to execute. Fallback to "MyDatabase" if the initial catalog can not be found in the connection string.